### PR TITLE
Fix build for aarch64

### DIFF
--- a/src/svm/kernel/rbf.rs
+++ b/src/svm/kernel/rbf.rs
@@ -1,4 +1,5 @@
 use std::convert::{From, TryFrom};
+use std::arch;
 
 use super::{KernelDense, KernelSparse};
 use crate::{
@@ -66,7 +67,7 @@ fn compute(rbf: Rbf, vectors: &MatrixD<f32s, Rows>, feature: &VectorD<f32s>, out
 #[cfg(target_arch = "aarch64")]
 #[inline]
 fn compute(rbf: Rbf, vectors: &MatrixD<f32s, Rows>, feature: &VectorD<f32s>, output: &mut [f64]) {
-    if is_aarch64_feature_detected!("neon") {
+    if arch::is_aarch64_feature_detected!("neon") {
         unsafe { compute_neon(rbf, vectors, feature, output) }
     } else {
         compute_core(rbf, vectors, feature, output)


### PR DESCRIPTION
I tried using `ffsvm` on aarch64, but after fixing [simd_aligned](https://github.com/ralfbiedert/simd_aligned/pull/2), the build fails in ffsvm.
That's because in comparison to `is_x86_feature_detected`, the [is_aarch64_feature_detected](https://doc.rust-lang.org/stable/std/arch/macro.is_aarch64_feature_detected.html#) macro is in the `std::arch` namespace instead of `std` (?!).
This fixes the build for me.